### PR TITLE
RPPM fiddling

### DIFF
--- a/scripts/mop_combat.py
+++ b/scripts/mop_combat.py
@@ -45,7 +45,7 @@ test_oh = stats.Weapon(10478.5, 2.6, 'fist', 'dancing_steel')
 #test_oh = stats.Weapon(7254.0, 1.8, 'dagger', 'dancing_steel')
 
 # Set up procs.
-test_procs = procs.ProcsList( ('heroic_bottle_of_infinite_stars', 2), ('heroic_terror_in_the_mists', 2) )
+test_procs = procs.ProcsList( 'renatakis_soul_charm' )
 
 # Set up gear buffs.
 test_gear_buffs = stats.GearBuffs('rogue_t14_2pc', 'rogue_t14_4pc', 'leather_specialization', 'virmens_bite', 'virmens_bite_prepot', 'chaotic_metagem')
@@ -82,15 +82,19 @@ mh_enchants_and_dps_ep_values, oh_enchants_and_dps_ep_values = calculator.get_we
 trinkets_list = [
     #5.2
     'heroic_rune_of_re_origination',
+    'thunder_rune_of_re_origination',
     'rune_of_re_origination',
     'lfr_rune_of_re_origination',
     'heroic_bad_juju',
+    'thunder_bad_juju',
     'bad_juju',
     'lfr_bad_juju',
     'heroic_talisman_of_bloodlust',
+    'thunder_talisman_of_bloodlust',
     'talisman_of_bloodlust',
     'lfr_talisman_of_bloodlust',
     'heroic_renatakis_soul_charm',
+    'thunder_renatakis_soul_charm',
     'renatakis_soul_charm',
     'lfr_renatakis_soul_charm',
     'vicious_talisman_of_the_shado-pan_assault',
@@ -105,18 +109,22 @@ trinkets_list = [
 ]
 trinkets_ep_value = calculator.get_other_ep(trinkets_list)
 trinkets_ep_value['heroic_rune_of_re_origination'] += 1657 * ep_values['agi']
+trinkets_ep_value['thunder_rune_of_re_origination'] += 1552 * ep_values['agi']
 trinkets_ep_value['rune_of_re_origination'] += 1467 * ep_values['agi']
 trinkets_ep_value['lfr_rune_of_re_origination'] += 1218 * ep_values['agi']
 trinkets_ep_value['heroic_bad_juju'] += .6 * 1657 * ep_values['mastery'] + .4 * 1657 * ep_values['haste']
+trinkets_ep_value['thunder_bad_juju'] += .6 * 1552 * ep_values['mastery'] + .4 * 1552 * ep_values['haste']
 trinkets_ep_value['bad_juju'] += .6 * 1467 * ep_values['mastery'] + .4 * 1467 * ep_values['haste']
 trinkets_ep_value['lfr_bad_juju'] += .6 * 1218 * ep_values['mastery'] + .4 * 1218 * ep_values['haste']
 trinkets_ep_value['heroic_talisman_of_bloodlust'] += 1657 * ep_values['agi']
+trinkets_ep_value['thunder_talisman_of_bloodlust'] += 1552 * ep_values['agi']
 trinkets_ep_value['talisman_of_bloodlust'] += 1467 * ep_values['agi']
 trinkets_ep_value['lfr_talisman_of_bloodlust'] += 1218 * ep_values['agi']
 trinkets_ep_value['heroic_renatakis_soul_charm'] += .6 * 1657 * ep_values['dodge_exp'] + .4 * 1657 * ep_values['haste']
+trinkets_ep_value['thunder_renatakis_soul_charm'] += .6 * 1552 * ep_values['dodge_exp'] + .4 * 1552 * ep_values['haste']
 trinkets_ep_value['renatakis_soul_charm'] += .6 * 1467 * ep_values['dodge_exp'] + .4 * 1467 * ep_values['haste']
 trinkets_ep_value['lfr_renatakis_soul_charm'] += .6 * 1218 * ep_values['dodge_exp'] + .4 * 1218 * ep_values['haste']
-trinkets_ep_value['vicious_talisman_of_the_shado-pan_assault']
+trinkets_ep_value['vicious_talisman_of_the_shado-pan_assault'] += .6 *  1467 * ep_values['white_hit'] + .4 * 1467 * ep_values['haste']
 
 trinkets_ep_value['heroic_bottle_of_infinite_stars'] += 731 * ep_values['mastery'] + 487 * ep_values['haste']
 trinkets_ep_value['bottle_of_infinite_stars'] += 648 * ep_values['mastery'] + 431 * ep_values['haste']

--- a/shadowcraft/calcs/rogue/Aldriana/__init__.py
+++ b/shadowcraft/calcs/rogue/Aldriana/__init__.py
@@ -290,7 +290,7 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
 
         if self.stats.procs.heroic_matrix_restabilizer or self.stats.procs.matrix_restabilizer:
             self.set_matrix_restabilizer_stat(self.base_stats)
-        if self.stats.procs.heroic_rune_of_re_origination or self.stats.procs.rune_of_re_origination or self.stats.procs.lfr_rune_of_re_origination:
+        if self.stats.procs.heroic_rune_of_re_origination or self.stats.procs.thunder_rune_of_re_origination or self.stats.procs.rune_of_re_origination or self.stats.procs.lfr_rune_of_re_origination:
             self.set_re_origination_stat(self.base_stats)
         self.update_rppm_trinkets()
 
@@ -393,6 +393,10 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
         except:
             'ignore-error'
         try:
+            self.stats.procs.thunder_rune_of_re_origination.buffs = buff_cache
+        except:
+            'ignore-error'
+        try:
             self.stats.procs.rune_of_re_origination.buffs = buff_cache
         except:
             'ignore-error'
@@ -406,10 +410,11 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
         #  if proc is rppm
         #    mod rppm by 1/(1.15^( (528-ItemLevel)/15 ))
         for entry in self.stats.procs.allowed_procs:
-            tmp_proc = proc_data.behaviours[ self.stats.procs.allowed_procs[entry]['behaviours']['default'] ]
-            if 'real_ppm' in tmp_proc:
-                if tmp_proc['real_ppm']:
-                    tmp_proc['ppm'] = 1/(1.15**((528-self.stats.procs.allowed_procs[entry]['scaling']['item_level'])/15.0)) * tmp_proc['base_ppm']
+            if self.stats.procs.allowed_procs[entry]['behaviours']['default'] == "rune_of_re_origination":
+                tmp_proc = proc_data.behaviours[ self.stats.procs.allowed_procs[entry]['behaviours']['default'] ]
+                if 'real_ppm' in tmp_proc:
+                    if tmp_proc['real_ppm']:
+                        tmp_proc['ppm'] = 1/(1.15**((528-self.stats.procs.allowed_procs[entry]['scaling']['item_level'])/15.0)) * tmp_proc['base_ppm']
         #mod_table = {541: 1.1288, 535: 1.0674, 528: 1.0000,
         #             522: 0.9456, 502: 0.7849, 463: 0.5457}
         
@@ -779,7 +784,7 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
 
     def set_uptime(self, proc, attacks_per_second, crit_rates):
         procs_per_second = self.get_procs_per_second(proc, attacks_per_second, crit_rates)
-
+        print proc.proc_name, proc.value, "pps", procs_per_second, 1/procs_per_second, proc.ppm
         if proc.icd:
             proc.uptime = proc.duration / (proc.icd + 1. / procs_per_second)
         else:
@@ -1009,7 +1014,7 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
                             current_stats[ e[0] ] += proc.uptime * e[1]
                     else:
                         current_stats[proc.stat] += proc.uptime * proc.value
-                    print proc.proc_name, proc.uptime
+                    print proc.proc_name, "uptime", proc.uptime
 
             if windsong_enchants:
                 proc = windsong_enchants[0]

--- a/shadowcraft/objects/proc_data.py
+++ b/shadowcraft/objects/proc_data.py
@@ -29,6 +29,15 @@ allowed_procs = {
         'behaviours': {'default': 'rune_of_re_origination'},
         'scaling': {'factor': 0.0, 'item_level': 535, 'quality': 'epic'}
     },
+    'thunder_rune_of_re_origination': {
+        'stat': 'multi',
+        'value': 0,
+        'buffs': ('none', 0),
+        'duration': 10,
+        'proc_name': 'Rune of Re-Origination',
+        'behaviours': {'default': 'rune_of_re_origination'},
+        'scaling': {'factor': 0.0, 'item_level': 528, 'quality': 'epic'}
+    },
     'rune_of_re_origination': {
         'stat': 'multi',
         'value': 0,
@@ -55,6 +64,14 @@ allowed_procs = {
         'behaviours': {'default': 'bad_juju'},
         'scaling': {'factor': 2.4749999046, 'item_level': 535, 'quality': 'epic'}
     },
+    'thunder_bad_juju': {
+        'stat': 'agi',
+        'value': 7757,
+        'duration': 20,
+        'proc_name': 'Bad Juju',
+        'behaviours': {'default': 'bad_juju'},
+        'scaling': {'factor': 2.4749999046, 'item_level': 528, 'quality': 'epic'}
+    },
     'bad_juju': {
         'stat': 'agi',
         'value': 7333,
@@ -75,33 +92,37 @@ allowed_procs = {
         'stat': 'haste',
         'value': 1736,
         'duration': 10,
+        'max_stacks': 5,
         'proc_name': 'Talisman of Bloodlust',
         'behaviours': {'default': 'talisman_of_bloodlust'},
-        'scaling': {'factor': 0.5189999938*2.5, 'item_level': 535, 'quality': 'epic'} # Needs verification
+        'scaling': {'factor': 0.5189999938, 'item_level': 535, 'quality': 'epic'} # Needs verification
     },
     'thunder_talisman_of_bloodlust': {
         'stat': 'haste',
         'value': 1627,
         'duration': 10,
+        'max_stacks': 5,
         'proc_name': 'Talisman of Bloodlust',
         'behaviours': {'default': 'talisman_of_bloodlust'},
-        'scaling': {'factor': 0.5189999938*2.5, 'item_level': 528, 'quality': 'epic'} # Needs verification
+        'scaling': {'factor': 0.5189999938, 'item_level': 528, 'quality': 'epic'} # Needs verification
     },
     'talisman_of_bloodlust': {
         'stat': 'haste',
         'value': 1538,
         'duration': 10,
+        'max_stacks': 5,
         'proc_name': 'Talisman of Bloodlust',
         'behaviours': {'default': 'talisman_of_bloodlust'},
-        'scaling': {'factor': 0.5189999938*2.5, 'item_level': 522, 'quality': 'epic'} # Needs verification
+        'scaling': {'factor': 0.5189999938, 'item_level': 522, 'quality': 'epic'} # Needs verification
     },
     'lfr_talisman_of_bloodlust': {
         'stat': 'haste',
         'value': 1277,
         'duration': 10,
+        'max_stacks': 5,
         'proc_name': 'Talisman of Bloodlust',
         'behaviours': {'default': 'talisman_of_bloodlust'},
-        'scaling': {'factor': 0.5189999938*2.5, 'item_level': 502, 'quality': 'epic'} # Needs verification
+        'scaling': {'factor': 0.5189999938, 'item_level': 502, 'quality': 'epic'} # Needs verification
     },
     'heroic_renatakis_soul_charm': {
         'stat': 'agi',

--- a/shadowcraft/objects/procs.py
+++ b/shadowcraft/objects/procs.py
@@ -117,7 +117,7 @@ class Proc(object):
             else:
                 return self.ppm * speed / 60.
         elif self.is_real_ppm():
-            return haste * self.ppm / 60
+            return haste * self.ppm / 60.
         else:
             return self.proc_chance
 


### PR DESCRIPTION
Well the function with the proc_per_second were correct. My thought were wrong and the values skyrocked. But found another issue which should be bringing the trinkets in a good lineup. 
- update_rppm_trinkets:
  This function should only be called for the rune of re-origination trinkets. All other trinkets are not affected by this formula.
- I have also added the missing thunderforged trinkets
- changed the tlisman of bloodlust to stacks, instead of an avg case, if you think the avg case is better fell free to revert it, i havnt done any extensive tests only looking at some debug prints if these values make sense
- there are some debug prints which should be deleted
